### PR TITLE
Add Cloud Providers chapter.

### DIFF
--- a/installation/quick-installation.md
+++ b/installation/quick-installation.md
@@ -117,6 +117,12 @@ helm repo update
 helm install myleantime gissilabs/leantime
 ```
 
+## Installation on Cloud Provider
+
+Some hosting platforms, or Cloud Providers, provide a documentation (or even an easy process) to install Leantime.
+
+  * alwaysdata: [install Leantime from Marketplace](https://www.alwaysdata.com/en/marketplace/leantime/)
+  
 ## Subfolder installation
 
 We recommend running Leantime as the main application under a domain or subdomain (eg leantime.yourcompany.com), however it is possible to run Leantime within a subfolder (eg. yourcompany.com/leantime).


### PR DESCRIPTION
Some OS projects present a list of Cloud Providers. This is pretty useful for the users who does not really want to take care of the administration part, and sometimes really ease the installation process. So, I found it might be a good idea to have it here, since we (alwaysdata) provide a very fast Leantime installation process.
Regards