### PR TITLE
Update minimal time tracking duration

### DIFF
--- a/using-leantime/task-management.md
+++ b/using-leantime/task-management.md
@@ -59,11 +59,13 @@ Starting work will start a task timer that allows you to track the time spent on
  
   ![logo](../_images/getting-started/taskandtimestartwork.png)
   
-  Starting work will start a timer on the top of your screen next to *My Timesheet*.  Time is not tracked if work spent is less than 6 minutes long.
+  Starting work will start a timer on the top of your screen next to *My Timesheet*.  Time durations shorter than one minute will not be tracked.
   
   ![logo](../_images/getting-started/timestartwork.png)
   
   
+# Related
  
-Click [here](knowledge-base/agile.md) to read more on agile and then over [here](knowledge-base/task-management.md) to read more on Task Management.
+- [Agile](/knowledge-base/agile.md)
+- [Timesheets](/using-leantime/timesheets.md)
    

--- a/using-leantime/timesheets.md
+++ b/using-leantime/timesheets.md
@@ -15,7 +15,7 @@ Starting work will start a task timer that allows you to track the time spent on
  
   ![logo](../_images/getting-started/taskandtimestartwork.png)
   
-  Starting work will start a timer on the top of your screen next to *My Timesheet*.  Time is not tracked if work spent is less than 6 minutes long.
+  Starting work will start a timer on the top of your screen next to *My Timesheet*.  Time is not tracked, if work spent is less than one minute long.
   
   ![logo](../_images/getting-started/timestartwork.png)
   


### PR DESCRIPTION
- Set minimal time tracking duration to one minute (instead of 6). For reference, see  [this line of code.](https://github.com/Leantime/leantime/blob/v2.2.7/src/domain/timesheets/repositories/class.timesheets.php#L760)
- Repair broken links
    - Replace 'click here to read more about ...' with 'Related' section
    - One link was pointing to the current file. I replace it with `timesheets.md`