### PR TITLE
Capitalize Toyota

### DIFF
--- a/knowledge-base/whatislean.md
+++ b/knowledge-base/whatislean.md
@@ -1,5 +1,5 @@
 # Lean Methodology
-In our efforts to include the best methods of project management, we've incorporated Lean methodologies into our practice.  Not only are we looking at the agility component of Lean as in toyota manufacturing (kanban), 
+In our efforts to include the best methods of project management, we've incorporated Lean methodologies into our practice.  Not only are we looking at the agility component of Lean as in Toyota manufacturing (kanban), 
 we are also considering business model methods such as Lean for startups and research. 
 
 ### Synopsis


### PR DESCRIPTION
Toyota should be capitalized because it's a proper noun.