### PR TITLE
Fix typo in copyright year

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                 var footer = [
                     '<hr/>',
                     '<footer>',
-                    '<span><a href="https://leantime.io">Leantime</a> &copy;20222. </span>',
+                    '<span><a href="https://leantime.io">Leantime</a> &copy;2023. </span>',
                     '<span>Proudly published with <a href="https://github.com/docsifyjs/docsify/" target="_blank">docsify</a>.</span>',
                     '</footer>'
                 ].join('')


### PR DESCRIPTION
Replace "20222" with "2023"